### PR TITLE
Удалить событие шаттлов. Понизить баллы за событие и их набор в дальнейшем.

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -115,14 +115,14 @@ namespace Content.Shared.CCVar
         ///     Close to how long you expect a round to last, so you'll probably have to tweak this on downstreams.
         /// </summary>
         public static readonly CVarDef<float>
-            EventsRampingAverageEndTime = CVarDef.Create("events.ramping_average_end_time", 40f, CVar.ARCHIVE | CVar.SERVERONLY);
+            EventsRampingAverageEndTime = CVarDef.Create("events.ramping_average_end_time", 52f, CVar.ARCHIVE | CVar.SERVERONLY);
 
         /// <summary>
         ///     Average ending chaos modifier for the ramping event scheduler.
         ///     Max chaos chosen for a round will deviate from this
         /// </summary>
         public static readonly CVarDef<float>
-            EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 6f, CVar.ARCHIVE | CVar.SERVERONLY);
+            EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 4.2f, CVar.ARCHIVE | CVar.SERVERONLY);
 
         /// <summary>
         ///     Minimum time between meteor swarms in minutes.

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -280,7 +280,7 @@
     - id: SolidWallRustingVariationPass
     - id: ReinforcedWallRustingVariationPass
     - id: BasicPuddleMessVariationPass
-      prob: 0.99
+      prob: 0.70
       orGroup: puddleMess
     - id: BloodbathPuddleMessVariationPass
       prob: 0.01

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -1,53 +1,53 @@
-- type: entity
-  abstract: true
-  parent: BaseGameRule
-  id: BaseUnknownShuttleRule
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    weight: 5
-    reoccurrenceDelay: 30
-    duration: 1
-  - type: RuleGrids
-  - type: LoadMapRule
+#- type: entity
+#  abstract: true
+#  parent: BaseGameRule
+#  id: BaseUnknownShuttleRule
+#  components:
+#  - type: StationEvent
+#    startAnnouncement: station-event-unknown-shuttle-incoming
+#    startAudio:
+#      path: /Audio/Announcements/attention.ogg
+#    weight: 5
+#    reoccurrenceDelay: 30
+#    duration: 1
+#  - type: RuleGrids
+#  - type: LoadMapRule
 
-- type: entity
-  parent: BaseUnknownShuttleRule
-  id: UnknownShuttleCargoLost
-  components:
-  - type: LoadMapRule
-    preloadedGrid: ShuttleCargoLost
+#- type: entity
+#  parent: BaseUnknownShuttleRule
+#  id: UnknownShuttleCargoLost
+#  components:
+#  - type: LoadMapRule
+#    preloadedGrid: ShuttleCargoLost
 
-- type: entity
-  parent: BaseUnknownShuttleRule
-  id: UnknownShuttleTravelingCuisine
-  components:
-  - type: LoadMapRule
-    preloadedGrid: TravelingCuisine
+#- type: entity
+#  parent: BaseUnknownShuttleRule
+#  id: UnknownShuttleTravelingCuisine
+#  components:
+#  - type: LoadMapRule
+#    preloadedGrid: TravelingCuisine
 
-- type: entity
-  parent: BaseUnknownShuttleRule
-  id: UnknownShuttleDisasterEvacPod
-  components:
-  - type: LoadMapRule
-    preloadedGrid: DisasterEvacPod
+#- type: entity
+#  parent: BaseUnknownShuttleRule
+#  id: UnknownShuttleDisasterEvacPod
+#  components:
+#  - type: LoadMapRule
+#    preloadedGrid: DisasterEvacPod
 
-- type: entity
-  parent: BaseUnknownShuttleRule
-  id: UnknownShuttleHonki
-  components:
-  - type: StationEvent
-    weight: 2
-  - type: LoadMapRule
-    preloadedGrid: Honki
+#- type: entity
+#  parent: BaseUnknownShuttleRule
+#  id: UnknownShuttleHonki
+#  components:
+#  - type: StationEvent
+#    weight: 2
+#  - type: LoadMapRule
+#    preloadedGrid: Honki
 
-- type: entity
-  parent: BaseUnknownShuttleRule
-  id: UnknownShuttleSyndieEvacPod
-  components:
-  - type: StationEvent
-    weight: 2
-  - type: LoadMapRule
-    preloadedGrid: SyndieEvacPod
+#- type: entity
+#  parent: BaseUnknownShuttleRule
+#  id: UnknownShuttleSyndieEvacPod
+#  components:
+#  - type: StationEvent
+#    weight: 2
+#  - type: LoadMapRule
+#    preloadedGrid: SyndieEvacPod

--- a/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
+++ b/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
@@ -3,27 +3,27 @@
   path: /Maps/Shuttles/ShuttleEvent/striker.yml
   copies: 2
 
-- type: preloadedGrid
-  id: ShuttleCargoLost
-  path: /Maps/Shuttles/ShuttleEvent/lost_cargo.yml
-  copies: 2
+#- type: preloadedGrid
+#  id: ShuttleCargoLost
+#  path: /Maps/Shuttles/ShuttleEvent/lost_cargo.yml
+#  copies: 2
 
-- type: preloadedGrid
-  id: TravelingCuisine
-  path: /Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
-  copies: 2
+#- type: preloadedGrid
+#  id: TravelingCuisine
+#  path: /Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
+#  copies: 2
 
-- type: preloadedGrid
-  id: DisasterEvacPod
-  path: /Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
-  copies: 3
+#- type: preloadedGrid
+#  id: DisasterEvacPod
+#  path: /Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
+#  copies: 3
 
-- type: preloadedGrid
-  id: Honki
-  path: /Maps/Shuttles/ShuttleEvent/honki.yml
-  copies: 1
+#- type: preloadedGrid
+#  id: Honki
+#  path: /Maps/Shuttles/ShuttleEvent/honki.yml
+#  copies: 1
 
-- type: preloadedGrid
-  id: SyndieEvacPod
-  path: /Maps/Shuttles/ShuttleEvent/syndie_evacpod.yml
-  copies: 2
+#- type: preloadedGrid
+#  id: SyndieEvacPod
+#  path: /Maps/Shuttles/ShuttleEvent/syndie_evacpod.yml
+#  copies: 2


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Убираем ротации с шаттлами спавнов, не требуется. 
Вероятность всех событий понижены на 20%, как и понижен набор поинтов, так как он слишком быстрый.

:cl:
- remove: ивенты со спавном шаттлов убраны.
- tweak: понижены шансы на событие на 10%
- tweak: понижен набор поинтов для собитий на 20%

