### PR TITLE
Disable VentClog event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -358,21 +358,21 @@
     lightBreakChancePerSecond: 0.0003
     doorToggleChancePerSecond: 0.001
 
-- type: entity
-  id: VentClog
-  parent: BaseStationEventLongDelay
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-vent-clog-start-announcement
-    startAudio:
-      path: /Audio/Announcements/ventclog.ogg # Corvax-Announcements
-      params:
-        volume: -4
-    earliestStart: 15
-    minimumPlayers: 15
-    weight: 5
-    duration: 60
-  - type: VentClogRule
+#- type: entity
+#  id: VentClog
+#  parent: BaseStationEventLongDelay
+#  components:
+#  - type: StationEvent
+#    startAnnouncement: station-event-vent-clog-start-announcement
+#    startAudio:
+#      path: /Audio/Announcements/ventclog.ogg # Corvax-Announcements
+#      params:
+#        volume: -4
+#    earliestStart: 15
+#    minimumPlayers: 15
+#    weight: 5
+#    duration: 60
+#  - type: VentClogRule
 
 - type: entity
   id: SlimesSpawn


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Отключает событие с вентиляцией и засиранием всего и вся. Неудивительно, что это сильно влияет на нагрузку сервера в целом.

:cl:
- remove: отключает событие с вентиляциие 

