### PR TITLE
Пониженное численость игроков для событий и режимов.

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -93,7 +93,8 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 20
+#    minPlayers: 20
+    minPlayers: 10   #cats
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: AntagSelection
@@ -228,7 +229,8 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 20
+#    minPlayers: 20
+    minPlayers: 10   #cats
     delay:
       min: 600
       max: 900

--- a/Resources/Prototypes/_Backmen/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Backmen/GameRules/roundstart.yml
@@ -4,7 +4,8 @@
   noSpawn: true
   components:
     - type: GameRule
-      minPlayers: 15
+#      minPlayers: 15
+      minPlayers: 10   #cats
     - type: FleshCultRule
       faction: Flesh
 
@@ -14,7 +15,8 @@
   noSpawn: true
   components:
   - type: GameRule
-    minPlayers: 15
+#    minPlayers: 10 
+    minPlayers: 15  #cats
   - type: BlobGameRule
 
 - type: entity
@@ -30,7 +32,8 @@
   noSpawn: true
   components:
   - type: GameRule
-    minPlayers: 15
+#    minPlayers: 10
+    minPlayers: 5  #cats
   - type: BloodsuckerRule
 
 - type: entity
@@ -47,7 +50,8 @@
   components:
   - type: StationEvent
     earliestStart: 50
-    minimumPlayers: 15
+#    minimumPlayers: 15
+    minimumPlayers: 5  #cats
     weight: 5
     duration: 1
   - type: BloodsuckerRule

--- a/Resources/Prototypes/_Backmen/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Backmen/GameRules/roundstart.yml
@@ -15,8 +15,8 @@
   noSpawn: true
   components:
   - type: GameRule
-#    minPlayers: 10 
-    minPlayers: 15  #cats
+#    minPlayers: 15 
+    minPlayers: 10  #cats
   - type: BlobGameRule
 
 - type: entity


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Пониженное численность игроков для событий и режимов.
Nukeops: 20 > 10
Zombie: 20 > 10
FleshCult: 15> 10
Blobe: 15 > 10
Vampires: 10 >5
VampireOutbreak: 50 > 10

:cl:
- tweak: Пониженное численность игроков для событий и режимов.
