### PR TITLE
Last Message Before Death Webhook.

### DIFF
--- a/Content.Server/Administration/Managers/BanEventArgs.cs
+++ b/Content.Server/Administration/Managers/BanEventArgs.cs
@@ -1,0 +1,39 @@
+using Content.Shared.Database;
+using Robust.Shared.Network;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Content.Server.Administration.Managers
+{
+    public class BanEventArgs
+    {
+        public class ServerBanEventArgs : EventArgs
+        {
+            public NetUserId? Target { get; }
+            public string? TargetUsername { get; }
+            public NetUserId? BanningAdmin { get; }
+            public (IPAddress, int)? AddressRange { get; }
+            public ImmutableArray<byte>? Hwid { get; }
+            public uint? Minutes { get; }
+            public NoteSeverity Severity { get; }
+            public string Reason { get; }
+
+            public ServerBanEventArgs(NetUserId? target, string? targetUsername, NetUserId? banningAdmin, (IPAddress, int)? addressRange, ImmutableArray<byte>? hwid, uint? minutes, NoteSeverity severity, string reason)
+            {
+                Target = target;
+                TargetUsername = targetUsername;
+                BanningAdmin = banningAdmin;
+                AddressRange = addressRange;
+                Hwid = hwid;
+                Minutes = minutes;
+                Severity = severity;
+                Reason = reason;
+            }
+        }
+    }
+}

--- a/Content.Server/Administration/Managers/BanManager.cs
+++ b/Content.Server/Administration/Managers/BanManager.cs
@@ -33,6 +33,8 @@ public sealed class BanManager : IBanManager, IPostInjectInit
     [Dependency] private readonly INetManager _netManager = default!;
     [Dependency] private readonly ILogManager _logManager = default!;
 
+    public event EventHandler<BanEventArgs.ServerBanEventArgs>? ServerBanCreated;
+
     private ISawmill _sawmill = default!;
 
     public const string SawmillId = "admin.bans";
@@ -178,6 +180,14 @@ public sealed class BanManager : IBanManager, IPostInjectInit
         // If they are, kick them
         var message = banDef.FormatBanMessage(_cfg, _localizationManager);
         targetPlayer.Channel.Disconnect(message);
+
+        OnServerBanCreated(new BanEventArgs.ServerBanEventArgs(target, targetUsername, banningAdmin, addressRange, hwid, minutes, severity, reason));
+
+    }
+
+    private void OnServerBanCreated(BanEventArgs.ServerBanEventArgs e)
+    {
+        ServerBanCreated?.Invoke(this, e);
     }
     #endregion
 

--- a/Content.Server/Administration/Managers/IBanManager.cs
+++ b/Content.Server/Administration/Managers/IBanManager.cs
@@ -12,6 +12,10 @@ namespace Content.Server.Administration.Managers;
 public interface IBanManager
 {
     public void Initialize();
+
+    // Define the event
+    event EventHandler<BanEventArgs.ServerBanEventArgs>? ServerBanCreated;
+    
     public void Restart();
 
     /// <summary>

--- a/Content.Server/Chat/LastMessageBeforeDeath.cs
+++ b/Content.Server/Chat/LastMessageBeforeDeath.cs
@@ -1,0 +1,199 @@
+using System.Text;
+using Content.Server.Discord;
+using Content.Shared.Mobs.Systems;
+using System.Threading.Tasks;
+using System.Collections.Specialized;
+using System.Collections;
+using Content.Server.GameTicking;
+using Content.Server.Administration.Managers;
+
+namespace Content.Server.Chat
+{
+    internal class LastMessageBeforeDeath
+    {
+
+#if DEBUG
+        [Dependency] private readonly ILogManager _logManager = default!;
+        private ISawmill _sawmill = default!;
+#endif
+        [Dependency] private readonly IBanManager _banManager = default!;
+
+        private readonly MobStateSystem _mobStateSystem;
+        private readonly GameTicker _gameTicker;
+
+
+        private OrderedDictionary _playerData = new OrderedDictionary();
+
+        // I don't think Chat needs it's own CVar file because of these two, so I'll leave them here...
+        private const int MessageDelayMilliseconds = 2000;
+        private const int MaxMessageSize = 2000; // CAN'T BE MORE THAN 2000! DISCORD LIMIT.
+        private const int MaxMessagesPerBatch = 15;
+        private const int MaxICLength = 128;
+
+        private static LastMessageBeforeDeath? _instance;
+        private static readonly object _lock = new object();
+
+        private static readonly Random _random = new Random();
+
+        // Private constructor to prevent instantiation
+        private LastMessageBeforeDeath()
+        {
+            IoCManager.InjectDependencies(this);
+            _mobStateSystem = IoCManager.Resolve<IEntityManager>().System<MobStateSystem>();
+            _gameTicker = IoCManager.Resolve<IEntityManager>().System<GameTicker>();
+            _banManager.ServerBanCreated += OnServerBanCreated;
+#if DEBUG
+            _sawmill = _logManager.GetSawmill("lastDeathMsgWebhook");
+#endif
+        }
+
+        // Public property to get the singleton instance
+        public static LastMessageBeforeDeath Instance
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    if (_instance == null)
+                    {
+                        _instance = new LastMessageBeforeDeath();
+                    }
+                    return _instance;
+                }
+            }
+        }
+
+        // Method to add a message for a player
+        public async void AddMessage(EntityUid source, string player, string message, string playerName)
+        {
+            if (message.Length > MaxICLength)
+            {
+                // if the message is bigger than the message length limit, we make it cut off at a random iterval.
+                // Example: Someone was giving a speech and got blown to bits.
+                int randomLength = _random.Next(1, MaxICLength);
+                message = message[..randomLength] + "-";
+            }
+
+            var currentTime = _gameTicker.RoundDuration();
+            string truncatedTime = $"{currentTime.Hours:D2}:{currentTime.Minutes:D2}:{currentTime.Seconds:D2}";
+            string formattedMessage = $"[{truncatedTime}] {playerName}: {message}";
+
+            if (!_playerData.Contains(player))
+            {
+                _playerData[player] = new OrderedDictionary();
+            }
+
+            var playerMessages = _playerData[player] as OrderedDictionary ?? throw new InvalidOperationException("Player messages dictionary is not initialized.");
+            playerMessages[playerName] = formattedMessage;
+            playerMessages["EntityUid"] = source;
+        }
+
+        // Send messages through the webhook on round end
+        public async void OnRoundEnd(WebhookIdentifier? webhookId)
+        {
+            if (!webhookId.HasValue)
+                return;
+
+            var id = webhookId.Value;
+            StringBuilder allMessagesString = new StringBuilder();
+            foreach (DictionaryEntry player in _playerData)
+            {
+                var playerMessages = player.Value as OrderedDictionary;
+                if (playerMessages != null)
+                {
+                    if (playerMessages["EntityUid"] is EntityUid playerUid && _mobStateSystem.IsDead(playerUid))
+                    {
+                        foreach (DictionaryEntry playerName in playerMessages)
+                        {
+                            if (playerName.Key.ToString() != "EntityUid")
+                            {
+                                allMessagesString.AppendLine($"{playerName.Value}");
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (allMessagesString.ToString().Length == 0)
+            {
+                allMessagesString.AppendLine($"No messages found.");
+            }
+
+            var messages = SplitMessage(allMessagesString.ToString(), MaxMessageSize);
+            var discordWebhook = new DiscordWebhook();
+            int messageCount = 0;
+            foreach (var message in messages)
+            {
+                if (messageCount >= MaxMessagesPerBatch)
+                {
+                    await Task.Delay(60000); // Wait for 1 minute
+                    messageCount = 0;
+                }
+                var payload = new WebhookPayload { Content = message };
+                var response = await discordWebhook.CreateMessage(id, payload);
+                messageCount++;
+
+                // Insert a small delay between each message
+                await Task.Delay(MessageDelayMilliseconds);
+
+                // Response still can be handled if needed.
+#if DEBUG
+                if (response.IsSuccessStatusCode)
+                {
+                    _sawmill.Debug("Last Messages Before Death sent successfully.");
+                }
+                else
+                {
+                    _sawmill.Error($"Failed to send last messages before death. Status code: {response.StatusCode}");
+                }
+#endif
+            }
+        }
+
+
+
+        private List<string> SplitMessage(string message, int chunkSize)
+        {
+            var messages = new List<string>();
+            int start = 0;
+
+            while (start < message.Length)
+            {
+                int end = start + chunkSize;
+
+                if (end >= message.Length)
+                {
+                    messages.Add(message.Substring(start));
+                    break;
+                }
+
+                int lastNewLine = message.LastIndexOf('\n', end);
+                if (lastNewLine > start)
+                {
+                    messages.Add(message.Substring(start, lastNewLine - start));
+                    start = lastNewLine + 1;
+                }
+                else
+                {
+                    messages.Add(message.Substring(start, chunkSize));
+                    start += chunkSize;
+                }
+            }
+
+            return messages;
+        }
+
+        private void OnServerBanCreated(object? sender, BanEventArgs.ServerBanEventArgs e)
+        {
+            // Handle the event
+            if (e.TargetUsername != null && _playerData.Contains(e.TargetUsername))
+            {
+                _playerData.Remove(e.TargetUsername);
+#if DEBUG
+                _sawmill.Info("A user was removed from last message list due to a ban.");
+#endif
+            }
+        }
+
+    }
+}

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -243,6 +243,14 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (string.IsNullOrEmpty(message))
             return;
 
+        //Last Message Before Death Webhook
+        var lastMessageSystem = LastMessageBeforeDeath.Instance;
+
+        if (player != null)
+        {
+            lastMessageSystem.AddMessage(source, player.Name, message, Name(source));
+        }
+
         // This message may have a radio prefix, and should then be whispered to the resolved radio channel
         if (checkRadioPrefix)
         {

--- a/Content.Server/GameTicking/GameTicker.CVars.cs
+++ b/Content.Server/GameTicking/GameTicker.CVars.cs
@@ -26,6 +26,8 @@ namespace Content.Server.GameTicking
 
         private WebhookIdentifier? _webhookIdentifier;
 
+        private WebhookIdentifier? _webhookIdentifierLastMessage;
+
         [ViewVariables]
         private string? RoundEndSoundCollection { get; set; }
 
@@ -70,6 +72,14 @@ namespace Content.Server.GameTicking
                 if (value == string.Empty)
                 {
                     DiscordRoundEndRole = null;
+                }
+            }, true);
+            //CCVar for DiscordLastMessageBeforeDeathWebhook
+            Subs.CVar(_configurationManager, CCVars.DiscordLastMessageBeforeDeathWebhook, value =>
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    _discord.GetWebhook(value, data => _webhookIdentifierLastMessage = data.ToIdentifier());
                 }
             }, true);
             Subs.CVar(_configurationManager, CCVars.RoundEndSoundCollection, value => RoundEndSoundCollection = value, true);

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Announcements;
+using Content.Server.Chat;
 using Content.Server.Discord;
 using Content.Server.GameTicking.Events;
 using Content.Server.Ghost;
@@ -342,6 +343,9 @@ namespace Content.Server.GameTicking
 
             ShowRoundEndScoreboard(text);
             SendRoundEndDiscordMessage();
+            // Call the OnEndRound to send the message through Last Message Before Death Webhook.
+            var lastMessageSystem = LastMessageBeforeDeath.Instance;
+            lastMessageSystem.OnRoundEnd(_webhookIdentifierLastMessage);
         }
 
         public void ShowRoundEndScoreboard(string text = "")

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -508,6 +508,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> DiscordBanAvatar =
             CVarDef.Create("discord.ban_avatar", string.Empty, CVar.SERVERONLY);
 
+        /// <summary>
+        /// URL of the Discord webhook which will relay last messages before death.
+        /// </summary>
+        public static readonly CVarDef<string> DiscordLastMessageBeforeDeathWebhook =
+            CVarDef.Create("discord.last_message_before_death_webhook", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL);
+
         /*
          * Tips
          */


### PR DESCRIPTION
**О PR**

Этот PR вводит дополнительную функцию вебхука, которая отправляет последние сообщения персонажей (IC) мертвых игроков перед их смертью в конце раунда.

**Изменения**
🆑 

add: Добавлен необязательный вебхук, который отправляет сообщения, сказанные игроками перед их смертью, в конце раунда.

