### PR TITLE
disable planet generator

### DIFF
--- a/Content.Server/Gateway/Systems/GatewayGeneratorSystem.cs
+++ b/Content.Server/Gateway/Systems/GatewayGeneratorSystem.cs
@@ -82,11 +82,11 @@ public sealed class GatewayGeneratorSystem : EntitySystem
             return;
 
         generator.NextUnlock = TimeSpan.FromMinutes(5);
-
-        for (var i = 0; i < 3; i++)
-        {
-            GenerateDestination(uid, generator);
-        }
+    // disable planet generator
+    //    for (var i = 0; i < 3; i++)
+    //    {
+    //        GenerateDestination(uid, generator);
+    //    }
     }
 
     private void GenerateDestination(EntityUid uid, GatewayGeneratorComponent? generator = null)


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Отключение генерации планет, который никогда не пользовались - и нужны лишь для Gate врат.

:cl:
- remove: раунд стартовые планеты
