### PR TITLE
Светошумовые станят на некоторое время.

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -154,7 +154,7 @@ namespace Content.Server.Explosion.EntitySystems
         private void HandleFlashTrigger(EntityUid uid, FlashOnTriggerComponent component, TriggerEvent args)
         {
             // TODO Make flash durations sane ffs.
-            _flashSystem.FlashArea(uid, args.User, component.Range, component.Duration * 1000f, probability: component.Probability);
+            _flashSystem.FlashArea(uid, args.User, component.Range, component.Duration * 1000f, probability: component.Probability, stun: component.Stun, stunDuration: component.StunDuration); // cats stun meta
             args.Handled = true;
         }
 

--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -152,7 +152,7 @@ namespace Content.Server.Flash
             }
         }
 
-        public void FlashArea(Entity<FlashComponent?> source, EntityUid? user, float range, float duration, float slowTo = 0.8f, bool displayPopup = false, float probability = 1f, SoundSpecifier? sound = null)
+        public void FlashArea(Entity<FlashComponent?> source, EntityUid? user, float range, float duration, float slowTo = 0.8f, bool displayPopup = false, float probability = 1f, SoundSpecifier? sound = null, bool stun = false, float stunDuration = 1f) // cats stun-meta
         {
             var transform = Transform(source);
             var mapPosition = _transform.GetMapCoordinates(transform);
@@ -174,7 +174,7 @@ namespace Content.Server.Flash
                     continue;
 
                 // They shouldn't have flash removed in between right?
-                Flash(entity, user, source, duration, slowTo, displayPopup);
+                Flash(entity, user, source, duration, slowTo, displayPopup, melee: stun, stunDuration: TimeSpan.FromSeconds(stunDuration)); // cats stan-meta
             }
 
             _audio.PlayPvs(sound, source, AudioParams.Default.WithVolume(1f).WithMaxDistance(3f));

--- a/Content.Shared/Flash/Components/FlashOnTriggerComponent.cs
+++ b/Content.Shared/Flash/Components/FlashOnTriggerComponent.cs
@@ -10,4 +10,8 @@ public sealed partial class FlashOnTriggerComponent : Component
     [DataField] public float Range = 1.0f;
     [DataField] public float Duration = 8.0f;
     [DataField] public float Probability = 1.0f;
+    // cats stun-meta
+    [DataField] public bool Stun = false;
+    [DataField] public float StunDuration = 2.0f;
+    // cats stun-metan
 }

--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -97,6 +97,7 @@
     - type: DeleteOnTrigger
     - type: FlashOnTrigger
       range: 6
+      stun: true # cats stun-meta
     - type: EmitSoundOnTrigger
       sound:
         path: "/Audio/Effects/flash_bang.ogg"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -67,6 +67,7 @@
     sprite: Objects/Weapons/Grenades/flashbang.rsi
   - type: FlashOnTrigger
     range: 7
+    stun: true # cats stun-meta
   - type: SoundOnTrigger
     sound:
       path: "/Audio/Effects/flash_bang.ogg"


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Светошумовые стали более полезные. Теперь они оглушают на котороткое время. Свойство ослепление всё так же остались.

:cl:
- tweak: шумовые гранаты так же станят на короткое время.
