### PR TITLE
Игровые событие для низкого онлайна.

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -180,7 +180,7 @@ namespace Content.Shared.CCVar
         ///     The preset for the game to fall back to if the selected preset could not be used, and fallback is enabled.
         /// </summary>
         public static readonly CVarDef<string>
-            GameLobbyFallbackPreset = CVarDef.Create("game.fallbackpreset", "Traitor,Extended", CVar.ARCHIVE);
+            GameLobbyFallbackPreset = CVarDef.Create("game.fallbackpreset", "Secret", CVar.ARCHIVE);
 
         /// <summary>
         ///     Controls if people can win the game in Suspicion or Deathmatch.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -122,7 +122,7 @@
     weight: 6.5
     earliestStart: 40
     reoccurrenceDelay: 20
-    minimumPlayers: 20
+    minimumPlayers: 10
   - type: AntagRandomSpawn
   - type: AntagSpawner
     prototype: MobDragon
@@ -152,7 +152,7 @@
     duration: null
     earliestStart: 30
     reoccurrenceDelay: 20
-    minimumPlayers: 30
+    minimumPlayers: 10
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
     # Vox disabled until loadouts work on AntagSelection-based spawns
@@ -203,7 +203,7 @@
     weight: 7.5
     duration: 1
     earliestStart: 45
-    minimumPlayers: 20
+    minimumPlayers: 10
   - type: RandomSpawnRule
     prototype: MobRevenant
 
@@ -217,23 +217,24 @@
 #    duration: 1
 #  - type: FalseAlarmRule
 
-- type: entity
-  id: GasLeak
-  parent: BaseStationEventShortDelay
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-gas-leak-start-announcement
-    startAudio:
-      path: /Audio/Announcements/gasleak_start.ogg # Corvax-Announcements
-      params:
-        volume: -4
-    endAnnouncement: station-event-gas-leak-end-announcement
-    weight: 8
-    endAudio:
-      path: /Audio/Announcements/gasleak_end.ogg # Corvax-Announcements
-      params:
-        volume: -4
-  - type: GasLeakRule
+# DISABLE_EVENTS
+#- type: entity
+#  id: GasLeak
+#  parent: BaseStationEventShortDelay
+#  components:
+#  - type: StationEvent
+#    startAnnouncement: station-event-gas-leak-start-announcement
+#    startAudio:
+#      path: /Audio/Announcements/gasleak_start.ogg # Corvax-Announcements
+#      params:
+#        volume: -4
+#    endAnnouncement: station-event-gas-leak-end-announcement
+#    weight: 8
+#    endAudio:
+#      path: /Audio/Announcements/gasleak_end.ogg # Corvax-Announcements
+#      params:
+#        volume: -4
+#  - type: GasLeakRule
 
 - type: entity
   id: KudzuGrowth
@@ -431,7 +432,7 @@
   components:
   - type: StationEvent
     earliestStart: 50
-    minimumPlayers: 30
+    minimumPlayers: 10
     weight: 2
     duration: 1
   - type: ZombieRule
@@ -537,44 +538,45 @@
     sounds:
       collection: Paracusia
 
-- type: entity
-  id: ImmovableRodSpawn
-  parent: BaseGameRule
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-immovable-rod-start-announcement
-    #startAudio: # USE TTS
-    #  path: /Audio/Announcements/attention.ogg
-    weight: 3.5
-    duration: 1
-    earliestStart: 30
-    minimumPlayers: 20
-  - type: ImmovableRodRule
-    rodPrototypes:
-    - id: ImmovableRodKeepTilesStill
-      prob: 0.95
-      orGroup: rodProto
-    - id: ImmovableRodMop
-      prob: 0.0072
-      orGroup: rodProto
-    - id: ImmovableRodShark
-      prob: 0.0072
-      orGroup: rodProto
-    - id: ImmovableRodClown
-      prob: 0.0072
-      orGroup: rodProto
-    - id: ImmovableRodBanana
-      prob: 0.0072
-      orGroup: rodProto
-    - id: ImmovableRodHammer
-      prob: 0.0072
-      orGroup: rodProto
-    - id: ImmovableRodThrongler
-      prob: 0.0072
-      orGroup: rodProto
-    - id: ImmovableRodGibstick
-      prob: 0.0072
-      orGroup: rodProto
+# DISABLE_EVENTS
+#- type: entity
+#  id: ImmovableRodSpawn
+#  parent: BaseGameRule
+#  components:
+#  - type: StationEvent
+#    startAnnouncement: station-event-immovable-rod-start-announcement
+#    #startAudio: # USE TTS
+#    #  path: /Audio/Announcements/attention.ogg
+#    weight: 3.5
+#    duration: 1
+#    earliestStart: 30
+#    minimumPlayers: 20
+#  - type: ImmovableRodRule
+#    rodPrototypes:
+#    - id: ImmovableRodKeepTilesStill
+#      prob: 0.95
+#      orGroup: rodProto
+#    - id: ImmovableRodMop
+#      prob: 0.0072
+#      orGroup: rodProto
+#    - id: ImmovableRodShark
+#      prob: 0.0072
+#      orGroup: rodProto
+#    - id: ImmovableRodClown
+#      prob: 0.0072
+#      orGroup: rodProto
+#    - id: ImmovableRodBanana
+#      prob: 0.0072
+#      orGroup: rodProto
+#    - id: ImmovableRodHammer
+#      prob: 0.0072
+#      orGroup: rodProto
+#    - id: ImmovableRodThrongler
+#      prob: 0.0072
+#      orGroup: rodProto
+#    - id: ImmovableRodGibstick
+#      prob: 0.0072
+#      orGroup: rodProto
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_Backmen/GameRules/events.yml
+++ b/Resources/Prototypes/_Backmen/GameRules/events.yml
@@ -20,12 +20,12 @@
       minimumPlayers: 15
     - type: FugitiveRule
 
-- type: entity
-  id: WageScheduler
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-    - type: WageSchedulerRule
+#- type: entity
+#  id: WageScheduler
+#  parent: BaseGameRule
+#  noSpawn: true
+#  components:
+#    - type: WageSchedulerRule
 
 ## Regular station events
 - type: entity
@@ -48,7 +48,7 @@
     weight: 6.5
     duration: 1
     earliestStart: 50
-    minimumPlayers: 20
+    minimumPlayers: 10
     maxOccurrences: 1 # can only happen once per round
   - type: BlobSpawnRule
     carrierBlobProtos:

--- a/Resources/Prototypes/_Backmen/game_presets.yml
+++ b/Resources/Prototypes/_Backmen/game_presets.yml
@@ -1,15 +1,15 @@
-- type: gamePreset
-  id: Shipwrecked
-  alias:
-    - schiffbruch
-  name: shipwrecked-title
-  description: shipwrecked-description
-  minPlayers: 1
-  showInVote: false
-  isMiniGame: false
-  supportedMaps: ShipwreckedPool
-  rules:
-    - Shipwrecked
+#- type: gamePreset
+#  id: Shipwrecked
+#  alias:
+#    - schiffbruch
+#  name: shipwrecked-title
+#  description: shipwrecked-description
+#  minPlayers: 1
+#  showInVote: false
+#  isMiniGame: false
+#  supportedMaps: ShipwreckedPool
+#  rules:
+#    - Shipwrecked
 
 - type: gamePreset
   id: Vampires
@@ -34,7 +34,7 @@
   name: blob-title
   description: blob-description
   minPlayers: 10
-  showInVote: false
+  showInVote: true
   rules:
   - BlobGameMode
   - BasicStationEventScheduler
@@ -201,7 +201,8 @@
   - changeling
   name: changeling-gamemode-title
   description: changeling-gamemode-description
-  showInVote: false
+  showInVote: true
+  minPlayers: 5
   rules:
   - Changeling
   - SubGamemodesRule

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -3,7 +3,7 @@
   alias:
     - survival
   name: survival-title
-  showInVote: false # secret
+  showInVote: true # secret
   description: survival-description
   rules:
     - RampingStationEventScheduler
@@ -35,7 +35,7 @@
   - extended
   - shittersafari
   name: extended-title
-  showInVote: false #2boring2vote
+  showInVote: true #2boring2vote
   description: extended-description
   rules:
   - BasicStationEventScheduler
@@ -49,7 +49,7 @@
   - greenshift
   - shittersafarideluxeedition
   name: greenshift-title
-  showInVote: false #4boring4vote
+  showInVote: true #4boring4vote
   description: greenshift-description
   rules:
   - BasicRoundstartVariation
@@ -93,7 +93,7 @@
     - sandbox
   name: sandbox-title
   description: sandbox-description
-  showInVote: false # Not suitable for use without admin intervention, since entity spamming can quickly crash a server
+  showInVote: true # Not suitable for use without admin intervention, since entity spamming can quickly crash a server
   maxPlayers: 5
   rules:
     - Sandbox
@@ -104,7 +104,8 @@
     - traitor
   name: traitor-title
   description: traitor-description
-  showInVote: false
+  showInVote: true
+  minPlayers: 6
   rules:
     - Traitor
     - SubGamemodesRule
@@ -121,8 +122,8 @@
   name: death-match-title
   description: death-match-description
   maxPlayers: 15
-  showInVote: true
-  isMiniGame: true
+  showInVote: false
+  isMiniGame: false
   supportedMaps: DeathMatchMapPool
   rules:
     - DeathMatch31
@@ -150,7 +151,8 @@
     - revolutionaries
   name: rev-title
   description: rev-description
-  showInVote: false
+  showInVote: true
+  minPlayers: 10
   rules:
     - Revolutionary
     - SubGamemodesRule
@@ -169,7 +171,8 @@
   - zomber
   name: zombie-title
   description: zombie-description
-  showInVote: false
+  showInVote: true
+  minPlayers: 10
   rules:
   - Zombie
   - BasicStationEventScheduler


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Снижение требуемых игроков для событий.
Теперь в зависимости от количество игроков, будут открываться дополнительные голосование за режимы игры.

:cl:
- tweak: снижение требуемых игроков для событий.
- tweak: теперь в зависимости от количество игроков, будут открываться дополнительные голосование за режимы игры.