### PR TITLE
Ассистент ЦК, Грузчик ЦК, Офицер ЦК теперь доступны только по ВЛ

### DIFF
--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/cargotech.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/cargotech.yml
@@ -11,6 +11,7 @@
   weight: 1
   requireAdminNotify: true
   joinNotifyCrew: true
+  whitelisted: true
   requirements:
     - !type:DepartmentTimeRequirement
       department: Cargo

--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/intern.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/intern.yml
@@ -11,6 +11,7 @@
   weight: 1
   requireAdminNotify: true
   joinNotifyCrew: true
+  whitelisted: true
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering

--- a/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/private_officer.yml
+++ b/Resources/Prototypes/_Backmen/Roles/Jobs/CentCom/private_officer.yml
@@ -11,6 +11,7 @@
   weight: 1
   requireAdminNotify: true
   joinNotifyCrew: true
+  whitelisted: true
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Ассистент ЦК, Грузчик ЦК, Офицер ЦК теперь доступны только по ВЛ

:cl:
- tweak: Ассистент ЦК теперь только по ВЛ.
- tweak: Офицер ЦК теперь только по ВЛ.
- tweak: Грузчик ЦК теперь только по ВЛ.
