### PR TITLE
[PORT] Открытие шлюзов всегда сохраняет отпечатки

### DIFF
--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Access;
+using Content.Server.Forensics; // Cats-DoorForensics
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Doors.Components;
@@ -11,6 +12,7 @@ namespace Content.Server.Doors.Systems;
 public sealed class DoorSystem : SharedDoorSystem
 {
     [Dependency] private readonly AirtightSystem _airtightSystem = default!;
+    [Dependency] private readonly ForensicsSystem _forensicsSystem = default!; // Cats-DoorForensics
 
     public override void Initialize()
     {
@@ -50,4 +52,22 @@ public sealed class DoorSystem : SharedDoorSystem
         Dirty(ent, ent.Comp);
         UpdateBoltLightStatus(ent);
     }
+
+    // Cats-DoorForensics-Start
+    public override void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    {
+        base.StartOpening(uid, door, user, predicted);
+
+        if (user.HasValue)
+            _forensicsSystem.ApplyEvidence(user.Value, uid);
+    }
+
+    public override void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    {
+        base.StartClosing(uid, door, user, predicted);
+
+        if (user.HasValue)
+            _forensicsSystem.ApplyEvidence(user.Value, uid);
+    }
+	// Cats-DoorForensics-End
 }

--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -284,7 +284,7 @@ namespace Content.Server.Forensics
             return DNA;
         }
 
-        private void ApplyEvidence(EntityUid user, EntityUid target)
+        public void ApplyEvidence(EntityUid user, EntityUid target) // Cats-DoorForensics
         {
             if (HasComp<IgnoresFingerprintsComponent>(target))
                 return;

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -362,7 +362,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
     /// <param name="user"> The user (if any) opening the door</param>
     /// <param name="predicted">Whether the interaction would have been
     /// predicted. See comments in the PlaySound method on the Server system for details</param>
-    public void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    public virtual void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false) // Cats-DoorForensics
     {
         if (!Resolve(uid, ref door))
             return;
@@ -457,7 +457,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         return !ev.PerformCollisionCheck || !GetColliding(uid).Any();
     }
 
-    public void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    public virtual void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false) // Cats-DoorForensics
     {
         if (!Resolve(uid, ref door))
             return;


### PR DESCRIPTION
Port > https://github.com/space-syndicate/space-station-14-next/commit/516e286bb00c82ecd4a459f6ee9778118bc895df

Все шлюзы теперь всегда сохраняют отпечатки пальцев (или тип перчаток) при их открытии проходом через них, а не только когда по ним жмешь курсором для открытия.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые функции**
	- Добавлена поддержка судебной экспертизы при открытии и закрытии дверей, фиксируя действия пользователей.
	- Обновлена система судебной экспертизы для более эффективного применения и очистки доказательств.

- **Изменения в документации**
	- Изменена видимость методов, связанных с открытием и закрытием дверей, для улучшения расширяемости системы.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->