### PR TITLE
disable DealDamage

### DIFF
--- a/Content.Shared/Atmos/Rotting/RottingComponent.cs
+++ b/Content.Shared/Atmos/Rotting/RottingComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class RottingComponent : Component
     /// Whether or not the rotting should deal damage
     /// </summary>
     [DataField]
-    public bool DealDamage = true;
+    public bool DealDamage = false; // cats edit
 
     /// <summary>
     /// When the next check will happen for rot progression + effects like damage and ammonia


### PR DESCRIPTION
Убран урон от гниение.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Изменения в функциональности**
	- Значение по умолчанию для свойства `DealDamage` в компоненте гниения изменено с `true` на `false`, что означает, что компонент не будет наносить урон по умолчанию при инициировании гниения.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->