### PR TITLE
NanoChatUpdate

### DIFF
--- a/Content.Server/_Cats/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_Cats/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -399,7 +399,6 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
         _nanoChat.AddMessage((recipient, recipient.Comp), senderNumber.Value, message with { DeliveryFailed = false });
 
-
         if (recipient.Comp.IsClosed || _nanoChat.GetCurrentChat((recipient, recipient.Comp)) != senderNumber)
             HandleUnreadNotification(recipient, message);
 

--- a/Content.Server/_Cats/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_Cats/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -24,6 +24,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedNanoChatSystem _nanoChat = default!;
+    [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly StationSystem _station = default!;
 
     // Messages in notifications get cut off after this point
@@ -38,6 +39,20 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         SubscribeLocalEvent<NanoChatCartridgeComponent, CartridgeMessageEvent>(OnMessage);
     }
 
+    private void UpdateClosed(Entity<NanoChatCartridgeComponent> ent)
+    {
+        if (!TryComp<CartridgeComponent>(ent, out var cartridge) ||
+            cartridge.LoaderUid is not {} pda ||
+            !TryComp<CartridgeLoaderComponent>(pda, out var loader) ||
+            !GetCardEntity(pda, out var card))
+        {
+            return;
+        }
+
+        // if you switch to another program or close the pda UI, allow notifications for the selected chat
+        _nanoChat.SetClosed((card, card.Comp), loader.ActiveProgram != ent.Owner || !_ui.IsUiOpen(pda, PdaUiKey.Key));
+    }
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -48,6 +63,9 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         {
             if (cartridge.LoaderUid == null)
                 continue;
+
+            // keep it up to date without handling ui open/close events on the pda or adding code when changing active program
+            UpdateClosed((uid, nanoChat));
 
             // Check if we need to update our card reference
             if (!TryComp<PdaComponent>(cartridge.LoaderUid, out var pda))
@@ -382,7 +400,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         _nanoChat.AddMessage((recipient, recipient.Comp), senderNumber.Value, message with { DeliveryFailed = false });
 
 
-        if (_nanoChat.GetCurrentChat((recipient, recipient.Comp)) != senderNumber)
+        if (recipient.Comp.IsClosed || _nanoChat.GetCurrentChat((recipient, recipient.Comp)) != senderNumber)
             HandleUnreadNotification(recipient, message);
 
         var msgEv = new NanoChatMessageReceivedEvent(recipient);

--- a/Content.Shared/_Cats/NanoChat/NanoChatCardComponent.cs
+++ b/Content.Shared/_Cats/NanoChat/NanoChatCardComponent.cs
@@ -15,6 +15,13 @@ public sealed partial class NanoChatCardComponent : Component
     public uint? Number;
 
     /// <summary>
+    ///     Whether a PDA has this card's UI closed.
+    ///     Used for notifications.
+    /// </summary>
+    [DataField]
+    public bool IsClosed;
+
+    /// <summary>
     ///     All chat recipients stored on this card.
     /// </summary>
     [DataField]

--- a/Content.Shared/_Cats/NanoChat/SharedNanoChatSystem.cs
+++ b/Content.Shared/_Cats/NanoChat/SharedNanoChatSystem.cs
@@ -170,7 +170,7 @@ public abstract class SharedNanoChatSystem : EntitySystem
     /// </summary>
     public bool GetNotificationsMuted(Entity<NanoChatCardComponent?> card)
     {
-        if (!Resolve(card, ref card.Comp) || card.Comp.NotificationsMuted == muted)
+        if (!Resolve(card, ref card.Comp))
             return false;
 
         return card.Comp.NotificationsMuted;
@@ -181,7 +181,7 @@ public abstract class SharedNanoChatSystem : EntitySystem
     /// </summary>
     public void SetNotificationsMuted(Entity<NanoChatCardComponent?> card, bool muted)
     {
-        if (!Resolve(card, ref card.Comp))
+        if (!Resolve(card, ref card.Comp) || card.Comp.NotificationsMuted == muted)
             return;
 
         card.Comp.NotificationsMuted = muted;

--- a/Content.Shared/_Cats/NanoChat/SharedNanoChatSystem.cs
+++ b/Content.Shared/_Cats/NanoChat/SharedNanoChatSystem.cs
@@ -49,11 +49,22 @@ public abstract class SharedNanoChatSystem : EntitySystem
     /// </summary>
     public void SetNumber(Entity<NanoChatCardComponent?> card, uint number)
     {
-        if (!Resolve(card, ref card.Comp))
+        if (!Resolve(card, ref card.Comp) || card.Comp.Number == number)
             return;
 
         card.Comp.Number = number;
         Dirty(card);
+    }
+
+    /// <summary>
+    ///     Sets IsClosed for a card.
+    /// </summary>
+    public void SetClosed(Entity<NanoChatCardComponent?> card, bool closed)
+    {
+        if (!Resolve(card, ref card.Comp))
+            return;
+
+        card.Comp.IsClosed = closed;
     }
 
     /// <summary>
@@ -159,7 +170,7 @@ public abstract class SharedNanoChatSystem : EntitySystem
     /// </summary>
     public bool GetNotificationsMuted(Entity<NanoChatCardComponent?> card)
     {
-        if (!Resolve(card, ref card.Comp))
+        if (!Resolve(card, ref card.Comp) || card.Comp.NotificationsMuted == muted)
             return false;
 
         return card.Comp.NotificationsMuted;


### PR DESCRIPTION
Порт багфикса наночата - https://github.com/DeltaV-Station/Delta-v/pull/2565/commits/cd9583a80ae9a29fe6a639e6c7ea11222677c7b9
Теперь оповещения о сообщениях из НаноЧата появляются даже если КПК и приложение на нём закрыты.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые функции**
	- Добавлен флаг закрытия чата для карточки NanoChat
	- Реализована логика управления уведомлениями в зависимости от состояния интерфейса

- **Улучшения**
	- Оптимизирована система обработки сообщений
	- Добавлена проверка состояния пользовательского интерфейса перед отправкой уведомлений

- **Исправления**
	- Предотвращено повторное обновление числовых значений
	- Улучшена логика определения состояния чата

<!-- end of auto-generated comment: release notes by coderabbit.ai -->